### PR TITLE
Add tests POC setup steps

### DIFF
--- a/docs/course.rst
+++ b/docs/course.rst
@@ -66,6 +66,17 @@ installation.
     $ sudo podman exec client cp /etc/krb5.keytab /enrollment/ad.keytab
     $ sudo podman exec client rm /etc/krb5.keytab
 
+Setup tests POC repo
+====================
+
+.. code-block:: text
+
+    $ git clone https://github.com/pbrezina/sssd-tests-poc.git
+    $ cd sssd-tests-poc
+    $ python3 -m venv .venv
+    $ source .venv/bin/activate
+    $ pip3 install -r ./requirements.txt
+
 Is everything working?
 ======================
 


### PR DESCRIPTION
When starting the crash course steps from https://sssd-tests-poc.readthedocs.io/en/latest/course.html there is currently no indication that you need to clone the sssd-tests-poc repo at all. I needed to do this to get the `mhc.yaml` which works with sssd-ci-containers and also install python-multihost and jc modules.