### PR TITLE
Fix typos in sssd.py and constants.py

### DIFF
--- a/lib/multihost/constants.py
+++ b/lib/multihost/constants.py
@@ -12,7 +12,7 @@ from .topology import Topology, TopologyDomain
 class KnownTopology(Enum):
     """
     Well-known topologies that can be given to ``pytest.mark.topology``
-    directly. It it expected to use these values in favor of providing
+    directly. It is expected to use these values in favor of providing
     custom marker values.
 
     .. code-block:: python
@@ -36,7 +36,8 @@ class KnownTopology(Enum):
         name='ldap',
         topology=Topology(TopologyDomain('sssd', client=1, ldap=1, nfs=1)),
         domains=dict(test='sssd.ldap[0]'),
-        fixtures=dict(client='sssd.client[0]', ldap='sssd.ldap[0]', provider='sssd.ldap[0]', nfs='sssd.nfs[0]'),
+        fixtures=dict(client='sssd.client[0]', ldap='sssd.ldap[0]',
+                      provider='sssd.ldap[0]', nfs='sssd.nfs[0]'),
     )
     """
     .. topology-mark:: KnownTopology.LDAP
@@ -46,7 +47,8 @@ class KnownTopology(Enum):
         name='ipa',
         topology=Topology(TopologyDomain('sssd', client=1, ipa=1, nfs=1)),
         domains=dict(test='sssd.ipa[0]'),
-        fixtures=dict(client='sssd.client[0]', ipa='sssd.ipa[0]', provider='sssd.ipa[0]', nfs='sssd.nfs[0]'),
+        fixtures=dict(client='sssd.client[0]', ipa='sssd.ipa[0]',
+                      provider='sssd.ipa[0]', nfs='sssd.nfs[0]'),
     )
     """
     .. topology-mark:: KnownTopology.IPA
@@ -56,7 +58,8 @@ class KnownTopology(Enum):
         name='ad',
         topology=Topology(TopologyDomain('sssd', client=1, ad=1, nfs=1)),
         domains=dict(test='sssd.ad[0]'),
-        fixtures=dict(client='sssd.client[0]', ad='sssd.ad[0]', provider='sssd.ad[0]', nfs='sssd.nfs[0]'),
+        fixtures=dict(client='sssd.client[0]', ad='sssd.ad[0]',
+                      provider='sssd.ad[0]', nfs='sssd.nfs[0]'),
     )
     """
     .. topology-mark:: KnownTopology.AD
@@ -66,7 +69,8 @@ class KnownTopology(Enum):
         name='samba',
         topology=Topology(TopologyDomain('sssd', client=1, samba=1, nfs=1)),
         domains={'test': 'sssd.samba[0]'},
-        fixtures=dict(client='sssd.client[0]', samba='sssd.samba[0]', provider='sssd.samba[0]', nfs='sssd.nfs[0]'),
+        fixtures=dict(client='sssd.client[0]', samba='sssd.samba[0]',
+                      provider='sssd.samba[0]', nfs='sssd.nfs[0]'),
     )
     """
     .. topology-mark:: KnownTopology.Samba
@@ -75,9 +79,9 @@ class KnownTopology(Enum):
 
 class KnownTopologyGroup(Enum):
     """
-    Groups of well-known topologies that can be given to ``pytest.mark.topology``
-    directly. It it expected to use these values in favor of providing
-    custom marker values.
+    Groups of well-known topologies that can be given to
+    ``pytest.mark.topology`` directly. It is expected to use these values in
+    favor of providing custom marker values.
 
     The test is parametrized and runs multiple times, once per each topology.
 
@@ -89,7 +93,8 @@ class KnownTopologyGroup(Enum):
             assert True
     """
 
-    AnyProvider = [KnownTopology.AD, KnownTopology.IPA, KnownTopology.LDAP, KnownTopology.Samba]
+    AnyProvider = [KnownTopology.AD, KnownTopology.IPA, KnownTopology.LDAP,
+                   KnownTopology.Samba]
     """
     .. topology-mark:: KnownTopologyGroup.AnyProvider
     """

--- a/lib/multihost/constants.py
+++ b/lib/multihost/constants.py
@@ -36,8 +36,7 @@ class KnownTopology(Enum):
         name='ldap',
         topology=Topology(TopologyDomain('sssd', client=1, ldap=1, nfs=1)),
         domains=dict(test='sssd.ldap[0]'),
-        fixtures=dict(client='sssd.client[0]', ldap='sssd.ldap[0]',
-                      provider='sssd.ldap[0]', nfs='sssd.nfs[0]'),
+        fixtures=dict(client='sssd.client[0]', ldap='sssd.ldap[0]', provider='sssd.ldap[0]', nfs='sssd.nfs[0]'),
     )
     """
     .. topology-mark:: KnownTopology.LDAP
@@ -47,8 +46,7 @@ class KnownTopology(Enum):
         name='ipa',
         topology=Topology(TopologyDomain('sssd', client=1, ipa=1, nfs=1)),
         domains=dict(test='sssd.ipa[0]'),
-        fixtures=dict(client='sssd.client[0]', ipa='sssd.ipa[0]',
-                      provider='sssd.ipa[0]', nfs='sssd.nfs[0]'),
+        fixtures=dict(client='sssd.client[0]', ipa='sssd.ipa[0]', provider='sssd.ipa[0]', nfs='sssd.nfs[0]'),
     )
     """
     .. topology-mark:: KnownTopology.IPA
@@ -58,8 +56,7 @@ class KnownTopology(Enum):
         name='ad',
         topology=Topology(TopologyDomain('sssd', client=1, ad=1, nfs=1)),
         domains=dict(test='sssd.ad[0]'),
-        fixtures=dict(client='sssd.client[0]', ad='sssd.ad[0]',
-                      provider='sssd.ad[0]', nfs='sssd.nfs[0]'),
+        fixtures=dict(client='sssd.client[0]', ad='sssd.ad[0]', provider='sssd.ad[0]', nfs='sssd.nfs[0]'),
     )
     """
     .. topology-mark:: KnownTopology.AD
@@ -69,8 +66,7 @@ class KnownTopology(Enum):
         name='samba',
         topology=Topology(TopologyDomain('sssd', client=1, samba=1, nfs=1)),
         domains={'test': 'sssd.samba[0]'},
-        fixtures=dict(client='sssd.client[0]', samba='sssd.samba[0]',
-                      provider='sssd.samba[0]', nfs='sssd.nfs[0]'),
+        fixtures=dict(client='sssd.client[0]', samba='sssd.samba[0]', provider='sssd.samba[0]', nfs='sssd.nfs[0]'),
     )
     """
     .. topology-mark:: KnownTopology.Samba
@@ -79,9 +75,9 @@ class KnownTopology(Enum):
 
 class KnownTopologyGroup(Enum):
     """
-    Groups of well-known topologies that can be given to
-    ``pytest.mark.topology`` directly. It is expected to use these values in
-    favor of providing custom marker values.
+    Groups of well-known topologies that can be given to ``pytest.mark.topology``
+    directly. It is expected to use these values in favor of providing
+    custom marker values.
 
     The test is parametrized and runs multiple times, once per each topology.
 
@@ -93,8 +89,7 @@ class KnownTopologyGroup(Enum):
             assert True
     """
 
-    AnyProvider = [KnownTopology.AD, KnownTopology.IPA, KnownTopology.LDAP,
-                   KnownTopology.Samba]
+    AnyProvider = [KnownTopology.AD, KnownTopology.IPA, KnownTopology.LDAP, KnownTopology.Samba]
     """
     .. topology-mark:: KnownTopologyGroup.AnyProvider
     """

--- a/lib/multihost/utils/sssd.py
+++ b/lib/multihost/utils/sssd.py
@@ -22,8 +22,7 @@ class HostSSSD(MultihostUtility):
     All changes are automatically reverted when a test is finished.
     """
 
-    def __init__(self, host: MultihostHost, fs: HostFileSystem,
-                 svc: HostService, load_config: bool = False) -> None:
+    def __init__(self, host: MultihostHost, fs: HostFileSystem, svc: HostService, load_config: bool = False) -> None:
         super().__init__(host)
         self.fs = fs
         self.svc = svc
@@ -80,15 +79,13 @@ class HostSSSD(MultihostUtility):
         :type apply_config: bool, optional
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value,
-        defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
         :type debug_level:  str | None, optional
         :return: Running SSH process.
         :rtype: SSHProcess
         """
         if apply_config:
-            self.config_apply(check_config=check_config,
-                              debug_level=debug_level)
+            self.config_apply(check_config=check_config, debug_level=debug_level)
 
         return self.svc.async_start(service)
 
@@ -112,15 +109,13 @@ class HostSSSD(MultihostUtility):
         :type apply_config: bool, optional
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value,
-        defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
         :type debug_level:  str | None, optional
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
         if apply_config:
-            self.config_apply(check_config=check_config,
-                              debug_level=debug_level)
+            self.config_apply(check_config=check_config, debug_level=debug_level)
 
         return self.svc.start(service, raise_on_error=raise_on_error)
 
@@ -135,8 +130,7 @@ class HostSSSD(MultihostUtility):
         """
         return self.svc.async_stop(service)
 
-    def stop(self, service='sssd', *, raise_on_error: bool = True) \
-            -> SSHProcessResult:
+    def stop(self, service='sssd', *, raise_on_error: bool = True) -> SSHProcessResult:
         """
         Stop SSSD service. The call will wait until the operation is finished.
 
@@ -166,15 +160,13 @@ class HostSSSD(MultihostUtility):
         :type apply_config: bool, optional
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value,
-        defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
         :type debug_level:  str | None, optional
         :return: Running SSH process.
         :rtype: SSHProcess
         """
         if apply_config:
-            self.config_apply(check_config=check_config,
-                              debug_level=debug_level)
+            self.config_apply(check_config=check_config, debug_level=debug_level)
 
         return self.svc.async_restart(service)
 
@@ -188,8 +180,7 @@ class HostSSSD(MultihostUtility):
         debug_level: str | None = '0xfff0'
     ) -> SSHProcessResult:
         """
-        Restart SSSD service. The call will wait until the operation is
-        finished.
+        Restart SSSD service. The call will wait until the operation is finished.
 
         :param service: Service to start, defaults to 'sssd'
         :type service: str, optional
@@ -199,20 +190,17 @@ class HostSSSD(MultihostUtility):
         :type apply_config: bool, optional
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value,
-        defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
         :type debug_level:  str | None, optional
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
         if apply_config:
-            self.config_apply(check_config=check_config,
-                              debug_level=debug_level)
+            self.config_apply(check_config=check_config, debug_level=debug_level)
 
         return self.svc.restart(service, raise_on_error=raise_on_error)
 
-    def clear(self, *, db: bool = True, config: bool = False,
-              logs: bool = False):
+    def clear(self, *, db: bool = True, config: bool = False, logs: bool = False):
         """
         Clear SSSD data.
 
@@ -262,8 +250,7 @@ class HostSSSD(MultihostUtility):
         host = role.host
 
         if not isinstance(host, ProviderHost):
-            raise ValueError(f'Host type {type(host)} can not be imported as'
-                             f' domain')
+            raise ValueError(f'Host type {type(host)} can not be imported as domain')
 
         self.config[f'domain/{name}'] = host.client
         self.config['sssd'].setdefault('domains', '')
@@ -289,20 +276,17 @@ class HostSSSD(MultihostUtility):
         """
         Load remote SSSD configuration.
         """
-        result = self.host.ssh.exec(['cat', '/etc/sssd/sssd.conf'],
-                                    log_level=SSHLog.Short)
+        result = self.host.ssh.exec(['cat', '/etc/sssd/sssd.conf'], log_level=SSHLog.Short)
         self.config.clear()
         self.config.read_string(result.stdout)
 
-    def config_apply(self, check_config: bool = True,
-                     debug_level: str | None = '0xfff0') -> None:
+    def config_apply(self, check_config: bool = True, debug_level: str | None = '0xfff0') -> None:
         """
         Apply current configuration on remote host.
 
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value,
-        defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
         :type debug_level:  str | None, optional
         """
         cfg = self.__set_debug_level(debug_level)

--- a/lib/multihost/utils/sssd.py
+++ b/lib/multihost/utils/sssd.py
@@ -22,7 +22,8 @@ class HostSSSD(MultihostUtility):
     All changes are automatically reverted when a test is finished.
     """
 
-    def __init__(self, host: MultihostHost, fs: HostFileSystem, svc: HostService, load_config: bool = False) -> None:
+    def __init__(self, host: MultihostHost, fs: HostFileSystem,
+                 svc: HostService, load_config: bool = False) -> None:
         super().__init__(host)
         self.fs = fs
         self.svc = svc
@@ -79,13 +80,15 @@ class HostSSSD(MultihostUtility):
         :type apply_config: bool, optional
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value,
+        defaults to 0xfff0
         :type debug_level:  str | None, optional
         :return: Running SSH process.
         :rtype: SSHProcess
         """
         if apply_config:
-            self.config_apply(check_config=check_config, debug_level=debug_level)
+            self.config_apply(check_config=check_config,
+                              debug_level=debug_level)
 
         return self.svc.async_start(service)
 
@@ -109,13 +112,15 @@ class HostSSSD(MultihostUtility):
         :type apply_config: bool, optional
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value,
+        defaults to 0xfff0
         :type debug_level:  str | None, optional
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
         if apply_config:
-            self.config_apply(check_config=check_config, debug_level=debug_level)
+            self.config_apply(check_config=check_config,
+                              debug_level=debug_level)
 
         return self.svc.start(service, raise_on_error=raise_on_error)
 
@@ -130,7 +135,8 @@ class HostSSSD(MultihostUtility):
         """
         return self.svc.async_stop(service)
 
-    def stop(self, service='sssd', *, raise_on_error: bool = True) -> SSHProcessResult:
+    def stop(self, service='sssd', *, raise_on_error: bool = True) \
+            -> SSHProcessResult:
         """
         Stop SSSD service. The call will wait until the operation is finished.
 
@@ -160,13 +166,15 @@ class HostSSSD(MultihostUtility):
         :type apply_config: bool, optional
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value,
+        defaults to 0xfff0
         :type debug_level:  str | None, optional
         :return: Running SSH process.
         :rtype: SSHProcess
         """
         if apply_config:
-            self.config_apply(check_config=check_config, debug_level=debug_level)
+            self.config_apply(check_config=check_config,
+                              debug_level=debug_level)
 
         return self.svc.async_restart(service)
 
@@ -180,7 +188,8 @@ class HostSSSD(MultihostUtility):
         debug_level: str | None = '0xfff0'
     ) -> SSHProcessResult:
         """
-        Restart SSSD service. The call will wait until the operation is finished.
+        Restart SSSD service. The call will wait until the operation is
+        finished.
 
         :param service: Service to start, defaults to 'sssd'
         :type service: str, optional
@@ -190,17 +199,20 @@ class HostSSSD(MultihostUtility):
         :type apply_config: bool, optional
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value,
+        defaults to 0xfff0
         :type debug_level:  str | None, optional
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
         if apply_config:
-            self.config_apply(check_config=check_config, debug_level=debug_level)
+            self.config_apply(check_config=check_config,
+                              debug_level=debug_level)
 
         return self.svc.restart(service, raise_on_error=raise_on_error)
 
-    def clear(self, *, db: bool = True, config: bool = False, logs: bool = False):
+    def clear(self, *, db: bool = True, config: bool = False,
+              logs: bool = False):
         """
         Clear SSSD data.
 
@@ -222,7 +234,7 @@ class HostSSSD(MultihostUtility):
         if logs:
             cmd += ' /var/log/sssd/*'
 
-        self.host.ssh.run('rm -fr /var/lib/sss/db/* /var/log/sssd/*')
+        self.host.ssh.run(cmd)
 
     def enable_responder(self, responder: str) -> None:
         """
@@ -250,7 +262,8 @@ class HostSSSD(MultihostUtility):
         host = role.host
 
         if not isinstance(host, ProviderHost):
-            raise ValueError(f'Host type {type(host)} can not be imported as domain')
+            raise ValueError(f'Host type {type(host)} can not be imported as'
+                             f' domain')
 
         self.config[f'domain/{name}'] = host.client
         self.config['sssd'].setdefault('domains', '')
@@ -276,17 +289,20 @@ class HostSSSD(MultihostUtility):
         """
         Load remote SSSD configuration.
         """
-        result = self.host.ssh.exec(['cat', '/etc/sssd/sssd.conf'], log_level=SSHLog.Short)
+        result = self.host.ssh.exec(['cat', '/etc/sssd/sssd.conf'],
+                                    log_level=SSHLog.Short)
         self.config.clear()
         self.config.read_string(result.stdout)
 
-    def config_apply(self, check_config: bool = True, debug_level: str | None = '0xfff0') -> None:
+    def config_apply(self, check_config: bool = True,
+                     debug_level: str | None = '0xfff0') -> None:
         """
         Apply current configuration on remote host.
 
         :param check_config: Check configuration for typos, defaults to True
         :type check_config: bool, optional
-        :param debug_level: Automatically set debug level to the given value, defaults to 0xfff0
+        :param debug_level: Automatically set debug level to the given value,
+        defaults to 0xfff0
         :type debug_level:  str | None, optional
         """
         cfg = self.__set_debug_level(debug_level)
@@ -355,7 +371,7 @@ class HostSSSD(MultihostUtility):
         self.config[f'domain/{self.default_domain}'] = value
 
     @domain.deleter
-    def domain(self, value: dict[str, str]) -> None:
+    def domain(self) -> None:
         if self.default_domain is None:
             raise ValueError(f'{self.__class__}.default_domain is not set')
 
@@ -452,7 +468,8 @@ class HostSSSD(MultihostUtility):
     Configuration of sudo responder.
     """
 
-    def __config_dumps(self, cfg: configparser) -> str:
+    @staticmethod
+    def __config_dumps(cfg: configparser) -> str:
         """ Convert configparser to string. """
         with StringIO() as ss:
             cfg.write(ss)


### PR DESCRIPTION
There is no intention in this PR to fix similar errors in all project files.
Just typos that I found during developing of #12.

Fix line too long errors.
Fix "typos" errors.
Fix bug with missing `cmd` variable in `clear` method

Signed-off-by: Denis Karpelevich <dkarpele@redhat.com>